### PR TITLE
line endings, encoding

### DIFF
--- a/gqrx-panadapter.py
+++ b/gqrx-panadapter.py
@@ -55,7 +55,11 @@ def main():
             rs.send(b'f\n')
 
             rigfreq = int(rs.recv(1024))
-            lnbfreq = rigfreq - int(args.ifreq * 1e6)
+            ifreq = int(args.ifreq * 1e6)
+            if ifreq > 0:
+                lnbfreq = rigfreq - ifreq
+            else:
+                lnbfreq = rigfreq + ifreq
 
             gs.send('LNB_LO {} \r\n'.format(lnbfreq).encode('utf-8'))
             gs.recv(1024)

--- a/gqrx-panadapter.py
+++ b/gqrx-panadapter.py
@@ -57,7 +57,7 @@ def main():
             rigfreq = int(rs.recv(1024))
             lnbfreq = rigfreq - int(args.ifreq * 1e6)
 
-            gs.send('LNB_LO {}'.format(lnbfreq).encode())
+            gs.send('LNB_LO {} \r\n'.format(lnbfreq).encode('utf-8'))
             gs.recv(1024)
 
             time.sleep(args.interval / 1000.0)


### PR DESCRIPTION
Script broken on Gqrx 2.17.5, using Python 3.12.6. Adding \r\n fixed that. Shouldn't break older versions imho. Not tested on different versions, though.

* Added carriage return line feed on sending to Gqrx

* Specified utf-8 encoding explicitly

* Added support for negative intermediate frequencies.